### PR TITLE
Recording errors

### DIFF
--- a/dorchester/dotdensity.py
+++ b/dorchester/dotdensity.py
@@ -37,6 +37,7 @@ def plot(src, dest, keys, format=None, mode="w"):
     with Writer(dest, mode) as writer:
         for points, err in generate_points(src, *keys):
             writer.write_all(points)
+            writer.write_error(err)
 
 
 def generate_points(src, *keys):

--- a/dorchester/dotdensity.py
+++ b/dorchester/dotdensity.py
@@ -83,16 +83,16 @@ def points_in_shape(geom, population):
     """
     triangles = (t for t in triangulate(geom) if t.within(geom))
     points = []
-    err = population  # count down as we go
+    offset = -1 * population  # count up as we go
     for triangle in triangles:
         ratio = triangle.area / geom.area
         n = round(ratio * population)
-        err -= n
+        offset += n
         vertices = triangle.exterior.coords[:3]
         if n > 0:
-            points.append(points_on_triangle(vertices, n))
+            points.extend(points_on_triangle(vertices, n))
 
-    return list(chain(*points)), err
+    return points, offset
 
 
 # https://stackoverflow.com/questions/47410054/generate-random-locations-within-a-triangular-domain

--- a/dorchester/dotdensity.py
+++ b/dorchester/dotdensity.py
@@ -14,7 +14,7 @@ import numpy as np
 from shapely.geometry import shape
 from shapely.ops import triangulate
 
-from .point import Point
+from .point import Point, Error
 from .output import FILE_TYPES, FORMATS
 
 
@@ -35,18 +35,23 @@ def plot(src, dest, keys, format=None, mode="w"):
         raise TypeError(f"Unknown file type: {dest.name}")
 
     with Writer(dest, mode) as writer:
-        writer.write_all(generate_points(src, *keys))
+        for points, err in generate_points(src, *keys):
+            writer.write_all(points)
 
 
 def generate_points(src, *keys):
     """
     Generate dot-density data, reading from source and yielding points.
     Any keys given will be used to extract population properties from features.
+
+    For each feature, yield a two-tuple of:
+     - a list of Point objects
+     - the error offset for this polygon-population combination
     """
     with fiona.open(src) as source:
         for feature in source:
             for key in keys:
-                yield from points_in_feature(feature, key)
+                yield points_in_feature(feature, key)
 
 
 def points_in_feature(feature, key):
@@ -54,12 +59,16 @@ def points_in_feature(feature, key):
     Take a geojson *feature*, create a shape
     Get population from feature.properties using *key*
     Concatenate all points yielded from points_in_shape
+    return a two-tuple of:
+     - a list of Point objects
+     - the error tuple, containing an offset, group name and feature id
     """
     fid = feature.get("id")
     geom = shape(feature["geometry"])
     population = feature["properties"][key]
-    for x, y in chain(*points_in_shape(geom, population)):
-        yield Point(x, y, key, fid)
+    points, err = points_in_shape(geom, population)
+    points = [Point(x, y, key, fid) for (x, y) in points]
+    return points, Error(err, key, fid)
 
 
 def points_in_shape(geom, population):
@@ -68,15 +77,22 @@ def points_in_shape(geom, population):
     first, cut the shape into triangles
     then, give each triangle a portion of points based on relative area
     within each triangle, distribute points using a weighted average
-    yield each set of points (one yield per triangle)
+    return a two-tuple of:
+     - a list of (x, y) coordinates
+     - the error offset for this polygon-population combination
     """
     triangles = (t for t in triangulate(geom) if t.within(geom))
+    points = []
+    err = population  # count down as we go
     for triangle in triangles:
         ratio = triangle.area / geom.area
         n = round(ratio * population)
+        err -= n
         vertices = triangle.exterior.coords[:3]
         if n > 0:
-            yield points_on_triangle(vertices, n)
+            points.append(points_on_triangle(vertices, n))
+
+    return list(chain(*points)), err
 
 
 # https://stackoverflow.com/questions/47410054/generate-random-locations-within-a-triangular-domain

--- a/dorchester/dotdensity.py
+++ b/dorchester/dotdensity.py
@@ -35,10 +35,10 @@ def plot(src, dest, keys, format=None, mode="w"):
         raise TypeError(f"Unknown file type: {dest.name}")
 
     with Writer(dest, mode) as writer:
-        writer.write_all(points(src, *keys))
+        writer.write_all(generate_points(src, *keys))
 
 
-def points(src, *keys):
+def generate_points(src, *keys):
     """
     Generate dot-density data, reading from source and yielding points.
     Any keys given will be used to extract population properties from features.

--- a/dorchester/output.py
+++ b/dorchester/output.py
@@ -39,7 +39,12 @@ class Writer:
 
     def _get_error_path(self):
         stem = self.path.stem
-        return self.path.with_stem(f"{stem}.errors")
+        parent = self.path.parent
+        suffixes = self.path.suffixes
+
+        suffixes.insert(0, ".errors")
+        name = stem + "".join(suffixes)
+        return parent / name
 
     def open(self):
         raise NotImplementedError

--- a/dorchester/output.py
+++ b/dorchester/output.py
@@ -12,7 +12,7 @@ import csv
 import geojson
 from pathlib import Path
 
-from .point import Point
+from .point import Point, Error
 
 
 class Writer:
@@ -24,8 +24,9 @@ class Writer:
     **kwargs may be passed to underlying resources, like csv.writer
     """
 
-    def __init__(self, path, mode="w", **kwargs):
+    def __init__(self, path, mode="w", *, error_path=None, **kwargs):
         self.path = Path(path)
+        self.error_path = Path(error_path or self._get_error_path())
         self.mode = mode
         self._kwargs = kwargs
 
@@ -35,6 +36,10 @@ class Writer:
 
     def __exit__(self, type, value, traceback):
         self.close(type, value, traceback)
+
+    def _get_error_path(self):
+        stem = self.path.stem
+        return self.path.with_stem(f"{stem}.errors")
 
     def open(self):
         raise NotImplementedError
@@ -49,26 +54,46 @@ class Writer:
         for point in points:
             self.write(point)
 
+    def write_error(self, error):
+        raise NotImplementedError
+
+    def write_all_errors(self, errors):
+        for err in errors:
+            self.write_error(err)
+
 
 class CSVWriter(Writer):
     "Write points to a CSV file"
 
     def open(self):
+        # points
         self.fd = open(self.path, self.mode)
         self.writer = csv.writer(self.fd, **self._kwargs)
+
+        # errors
+        self.error_fd = open(self.error_path, self.mode)
+        self.error_writer = csv.writer(self.error_fd, **self._kwargs)
 
         # new file, write headings
         if self.mode == "w":
             self.writer.writerow(Point._fields)
+            self.error_writer.writerow(Error._fields)
 
     def close(self, type, value, traceback):
         self.fd.close()
+        self.error_fd.close()
 
     def write(self, point):
         self.writer.writerow(point)
 
     def write_all(self, points):
         self.writer.writerows(points)
+
+    def write_error(self, error):
+        self.error_writer.writerow(error)
+
+    def write_all_errors(self, errors):
+        self.error_writer.writerows(errors)
 
 
 class GeoJSONWriter(Writer):

--- a/dorchester/point.py
+++ b/dorchester/point.py
@@ -11,3 +11,7 @@ class Point(namedtuple("Point", ["x", "y", "group", "fid"])):
         geometry = self.__geo_interface__
         properties = {"group": self.group, "fid": self.fid}
         return {"type": "Feature", "properties": properties, "geometry": geometry}
+
+
+# for structuring error offsets
+Error = namedtuple("Error", ["offset", "group", "fid"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,6 @@ def test_plot(source, feature_collection, tmpdir):
     dest = tmpdir / "output.csv"
     errors = tmpdir / "output.errors.csv"
     population = sum(f.properties["population"] for f in feature_collection.features)
-    # tolerance = 4  # rounding
     runner = CliRunner()
 
     with runner.isolated_filesystem():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,9 @@ def test_version():
 
 def test_plot(source, feature_collection, tmpdir):
     dest = tmpdir / "output.csv"
+    errors = tmpdir / "output.errors.csv"
     population = sum(f.properties["population"] for f in feature_collection.features)
-    tolerance = 4  # rounding
+    # tolerance = 4  # rounding
     runner = CliRunner()
 
     with runner.isolated_filesystem():
@@ -24,7 +25,9 @@ def test_plot(source, feature_collection, tmpdir):
 
         assert result.exit_code == 0
         assert dest.exists()
+        assert errors.exists()
 
         points = list(csv.DictReader(dest.open()))
+        offset = sum(int(row["offset"]) for row in csv.DictReader(errors.open()))
 
-        assert abs(len(points) - population) < tolerance
+        assert (len(points) - offset) == population

--- a/tests/test_dotdensity.py
+++ b/tests/test_dotdensity.py
@@ -133,18 +133,3 @@ def test_multi_population(source, feature_collection):
         len([p for p in points if p.group == "households"]) - errors["households"]
         == households
     )
-
-
-def test_plot_csv(source, tmpdir):
-    "Try the whole thing here"
-    dest = tmpdir / "output.csv"
-    fc = geojson.loads(source.read_text())
-    population = sum(f.properties["population"] for f in fc.features)
-    tolerance = 5  # again, rounding
-
-    dotdensity.plot(source, dest, ["population"])
-
-    with dest.open() as d:
-        rows = list(csv.DictReader(d))
-
-    assert abs(len(rows) - population) < tolerance

--- a/tests/test_dotdensity.py
+++ b/tests/test_dotdensity.py
@@ -55,7 +55,7 @@ def test_points_in_shape():
 
     points, err = dotdensity.points_in_shape(geom, population)
 
-    assert len(points) + err == population
+    assert len(points) - err == population
 
 
 def test_plot_total_points(source):
@@ -67,14 +67,11 @@ def test_plot_total_points(source):
     assert 10 == len(fc.features)
     assert 1000 == population
 
-    points = []
-    total_err = 0
+    points, errors = zip(*dotdensity.generate_points(source, "population"))
+    points = list(itertools.chain(*points))
+    total_err = sum(e.offset for e in errors)
 
-    for p, err in dotdensity.generate_points(source, "population"):
-        points.extend(p)
-        total_err += err.offset
-
-    assert (len(points) + total_err) == population
+    assert (len(points) - total_err) == population
 
 
 def test_generate_points(source):
@@ -124,17 +121,16 @@ def test_multi_population(source, feature_collection):
         groups[group] = list(point_list)
 
     assert (
-        sum([len(points), errors["population"], errors["households"]])
-        == population + households
-    )
+        (len(points) - errors["population"] - errors["households"])
+    ) == population + households
 
     assert (
-        len([p for p in points if p.group == "population"]) + errors["population"]
+        len([p for p in points if p.group == "population"]) - errors["population"]
         == population
     )
 
     assert (
-        len([p for p in points if p.group == "households"]) + errors["households"]
+        len([p for p in points if p.group == "households"]) - errors["households"]
         == households
     )
 

--- a/tests/test_dotdensity.py
+++ b/tests/test_dotdensity.py
@@ -69,14 +69,14 @@ def test_plot_total_points(source):
     assert 10 == len(fc.features)
     assert 1000 == population
 
-    points = list(dotdensity.points(source, "population"))
+    points = list(dotdensity.generate_points(source, "population"))
 
     assert abs(len(points) - population) < tolerance
 
 
 def test_generate_points(source):
     "Check that we return the right data structure"
-    points = dotdensity.points(source, "population")
+    points = dotdensity.generate_points(source, "population")
 
     point = next(points)
 
@@ -91,7 +91,7 @@ def test_generate_points(source):
 def test_points_in_polygons(source):
     "Check that all points are in the correct polygons"
     fc = geojson.loads(source.read_text())
-    points = dotdensity.points(source, "population")
+    points = dotdensity.generate_points(source, "population")
 
     # group points by fid, check that each is within the corresponding polygon
     features = {f.id: f for f in fc.features}
@@ -107,7 +107,8 @@ def test_multi_population(source, feature_collection):
     ratio = households / population
     tolerance = 5
     points = sorted(
-        dotdensity.points(source, "population", "households"), key=lambda p: p.group
+        dotdensity.generate_points(source, "population", "households"),
+        key=lambda p: p.group,
     )
 
     groups = {}

--- a/tests/test_dotdensity.py
+++ b/tests/test_dotdensity.py
@@ -6,7 +6,7 @@ import pytest
 from shapely import geometry
 from shapely.ops import triangulate
 
-from dorchester.point import Point
+from dorchester.point import Point, Error
 from dorchester import dotdensity
 from conftest import feature
 
@@ -50,36 +50,42 @@ def test_total_area():
 
 def test_points_in_shape():
     f = feature(0, 8, population=100)
-    tolerance = 2  # account for rounding
-
     population = f.properties["population"]
     geom = geometry.shape(f.geometry)
-    points = list(itertools.chain(*dotdensity.points_in_shape(geom, population)))
 
-    assert abs(len(points) - population) < tolerance
+    points, err = dotdensity.points_in_shape(geom, population)
+
+    assert len(points) + err == population
 
 
 def test_plot_total_points(source):
     "Check that we're generating the correct number of points across features"
     fc = geojson.loads(source.read_text())
     population = sum(f.properties["population"] for f in fc.features)
-    tolerance = 3  # account for rounding
 
     # sanity checks
     assert 10 == len(fc.features)
     assert 1000 == population
 
-    points = list(dotdensity.generate_points(source, "population"))
+    points = []
+    total_err = 0
 
-    assert abs(len(points) - population) < tolerance
+    for p, err in dotdensity.generate_points(source, "population"):
+        points.extend(p)
+        total_err += err.offset
+
+    assert (len(points) + total_err) == population
 
 
 def test_generate_points(source):
     "Check that we return the right data structure"
-    points = dotdensity.generate_points(source, "population")
+    gen = dotdensity.generate_points(source, "population")
 
-    point = next(points)
+    points, err = next(gen)
+    point = points[0]
 
+    assert isinstance(err, Error)
+    assert isinstance(err.offset, int)
     assert isinstance(point, dotdensity.Point)
     assert isinstance(point.x, float)
     assert isinstance(point.y, float)
@@ -91,33 +97,45 @@ def test_generate_points(source):
 def test_points_in_polygons(source):
     "Check that all points are in the correct polygons"
     fc = geojson.loads(source.read_text())
-    points = dotdensity.generate_points(source, "population")
 
     # group points by fid, check that each is within the corresponding polygon
     features = {f.id: f for f in fc.features}
-    for point in points:
-        feature = features[int(point.fid)]
-        geom = geometry.shape(feature.geometry)
-        assert geom.contains(geometry.shape(point))
+    for points, err in dotdensity.generate_points(source, "population"):
+        for point in points:
+            feature = features[int(point.fid)]
+            geom = geometry.shape(feature.geometry)
+            assert geom.contains(geometry.shape(point))
 
 
 def test_multi_population(source, feature_collection):
     population = sum(f.properties["population"] for f in feature_collection.features)
     households = sum(f.properties["households"] for f in feature_collection.features)
     ratio = households / population
-    tolerance = 5
-    points = sorted(
-        dotdensity.generate_points(source, "population", "households"),
-        key=lambda p: p.group,
-    )
+
+    points = []
+    errors = {"population": 0, "households": 0}
+
+    for p, err in dotdensity.generate_points(source, "population", "households"):
+        points.extend(p)
+        errors[err.group] += err.offset
 
     groups = {}
     for group, point_list in itertools.groupby(points, lambda p: p.group):
         groups[group] = list(point_list)
 
-    assert abs(len(points) - (population + households)) < tolerance
-    assert round(len(groups["households"]) / len(groups["population"]), 2) == round(
-        ratio, 2
+    assert (
+        sum([len(points), errors["population"], errors["households"]])
+        == population + households
+    )
+
+    assert (
+        len([p for p in points if p.group == "population"]) + errors["population"]
+        == population
+    )
+
+    assert (
+        len([p for p in points if p.group == "households"]) + errors["households"]
+        == households
     )
 
 


### PR DESCRIPTION
Fixes #2 

Trying to remove all the cases where I needed error tolerance and hope for the best. Here's how this should work:

Running `dotdensity.points_in_feature(feature, population)` now returns a two-tuple containing a list of points and a new `Error` object.

That error object is another `namedtuple` with three fields:

- `offset`: positive means too many points were generated, negative for not enough
- `group`: a category or property key, same as on points
- `fid`: a feature ID, also like on points

What to do with those errors now?